### PR TITLE
Retrieve instance id instead of public_id in terminal output

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -3,7 +3,7 @@ name: Dispatch
 on:
   push:
     branches:
-      - main
+      - development
     paths-ignore:
       - '.github/**'
   workflow_dispatch:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,24 @@
+name: Dispatch
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  dispatch:
+
+    name: dispatch to validate
+    runs-on: ubuntu-latest
+      
+    steps:
+    
+      - run: ${{ tojson(github.event) }}
+        shell: cat {0}
+        
+      - run: |
+          curl -H "Authorization: token ${{ secrets.VALIDATE_REPO_GH_TOKEN }} " \
+          -H 'Accept: application/vnd.github.everest-preview+json' "${{ vars.VALIDATE_REPO_DISPATCH_URL }}" \
+          -d '{ "event_type": "submodule_dispatch", "client_payload": { "owner": "${{ github.event.repository.owner.login }}", "repo": "${{ github.event.repository.name }}", "branch": "${{ github.ref_name }}" } }'

--- a/models.py
+++ b/models.py
@@ -1107,6 +1107,19 @@ class ValidationOutcome(TimestampedBaseModel, IdObfuscator):
             'Observed': self.observed
         }
         return f' '.join(f'{k}={v}' for k, v in members.items() if v)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "instance_id": self.instance_public_id,
+            "validation_task_id": self.validation_task_public_id,
+            "feature": self.feature,
+            "feature_version": self.feature_version,
+            "severity": self.get_severity_display(),  # Convert the integer to a human-readable string
+            "outcome_code": self.outcome_code,
+            "expected": self.expected,
+            "observed": self.observed,
+        }
     
     @property
     def instance_public_id(self):

--- a/models.py
+++ b/models.py
@@ -1111,7 +1111,7 @@ class ValidationOutcome(TimestampedBaseModel, IdObfuscator):
     def to_dict(self):
         return {
             "id": self.id,
-            "instance_id": self.instance_public_id,
+            "instance_id": self.instance_id,
             "validation_task_id": self.validation_task_public_id,
             "feature": self.feature,
             "feature_version": self.feature_version,


### PR DESCRIPTION
The instance id doesn't need to be obfuscated for the Gherkin terminal output