### PR TITLE
IVS-135 Functional Parts to datamodel (VS Scorecards)

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -1,0 +1,24 @@
+name: Dispatch
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  dispatch:
+
+    name: dispatch to validate
+    runs-on: ubuntu-latest
+      
+    steps:
+    
+      - run: ${{ tojson(github.event) }}
+        shell: cat {0}
+        
+      - run: |
+          curl -H "Authorization: token ${{ secrets.VALIDATE_REPO_GH_TOKEN }} " \
+          -H 'Accept: application/vnd.github.everest-preview+json' "${{ vars.VALIDATE_REPO_DISPATCH_URL }}" \
+          -d '{ "event_type": "submodule_dispatch", "client_payload": { "owner": "${{ github.event.repository.owner.login }}", "repo": "${{ github.event.repository.name }}", "branch": "${{ github.ref_name }}" } }'

--- a/models.py
+++ b/models.py
@@ -1107,6 +1107,19 @@ class ValidationOutcome(TimestampedBaseModel, IdObfuscator):
             'Observed': self.observed
         }
         return f' '.join(f'{k}={v}' for k, v in members.items() if v)
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "instance_id": self.instance_public_id,
+            "validation_task_id": self.validation_task_public_id,
+            "feature": self.feature,
+            "feature_version": self.feature_version,
+            "severity": self.get_severity_display(),  # Convert the integer to a human-readable string
+            "outcome_code": self.outcome_code,
+            "expected": self.expected,
+            "observed": self.observed,
+        }
     
     @property
     def instance_public_id(self):


### PR DESCRIPTION
In combination with https://github.com/buildingSMART/ifc-gherkin-rules/pull/291 . 
I've added the tag hierarchy to the datamodel. However, we still wouldn't have enough information to colour the blocks for each functional parts (the feature name itself does not suffice). Therefore, I've also included this info in the data model. This allows us to retrieve the functional parts along with their sub-parts or parent parts directly from each instance of ValidationOutcome.

Usage:
1) **As a Static Class**:
    - **Retrieve Hierarchy**: 
        Retrieve the complete hierarchy of a functional part without needing to instantiate the `FunctionalPart` class.
        ```python
        hierarchy = FunctionalPart.get_hierarchy('GEM')
        # {
        #   'code': 'GEM', 
        #   'name': 'Geometry representation', 
        #   'sub_parts': [{'code': 'TAS', ...}, {'code': 'SWE', ...}, ...]
        # }
        ```
        This returns an overview of the entire hierarchy of the functional part with the code `'GEM'`, including all its subparts with their respective codes and descriptions.

    - **Get Sub-part Codes**:
        Retrieve only the codes of the sub-parts of a functional part.
        ```python
        sub_part_codes = [i['code'] for i in FunctionalPart.get_hierarchy('GEM')['sub_parts']]
        # ['TAS', 'SWE', 'MPD', 'BRP', 'TFM', 'BBX', 'RCO', 'CPD', 'ALS']
        ```

    - **Get Parent of a Sub-part**:
        Retrieve the parent of a specific functional part by its code.
        ```python
        parent = FunctionalPart.get_parent('ALS')
        # {'code': 'GEM', 'name': 'Geometry representation'}
        ```

2) **Within the Context of `ValidationOutcome`**:
    - **Storing Functional Parts**:
        When creating a `ValidationOutcome`, functional parts can be associated with it via the `functional_part_codes` attribute.
        ```python
        validation_outcome = ValidationOutcome(
            # Other attributes...
            functional_part_codes=FunctionalPart.filter_functional_part_tags(context.tags)
        )
        ```
        The `filter_functional_part_tags` method filters and retrieves relevant functional parts from the tags present in the Behave context (i.e. `context.feature.tags`).

    - **Accessing Functional Parts**:
        Once a `ValidationOutcome` instance is created, it's possible to ccess the associated functional parts along with their relevant information.
        ```python
        validation_outcome.functional_parts
        # [<FunctionalPart: ALS - Alignment geometry>, <FunctionalPart: GEM - Geometry representation>]
        ```

    - **Navigating Functional Part Hierarchies**:
        From each `FunctionalPart` in `validation_outcome.functional_parts`:
        - Get the parent of the functional part:
          ```python
          validation_outcome.functional_parts[0].parent
          # <FunctionalPart: GEM - Geometry representation>
          ```
        - Retrieve all possible sub-parts:
          ```python
          validation_outcome.functional_parts[1].sub_parts
          # [<FunctionalPart: TAS - Tessellated (i.e., meshes)>, <FunctionalPart: SWE - Sweeps (i.e., extrusions, lofts, blends)>, ...]
          ```
