### PR TITLE
IVS-629 - Ignore case when matching username + tests

### DIFF
--- a/migrations/0017_add_user_ci_index.py
+++ b/migrations/0017_add_user_ci_index.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ifc_validation_models', '0016_alter_validationrequest_channel'),
+    ]
+
+    operations = [
+        # '__iexact=' typically translates to UPPER(...) = UPPER(...) in SQL
+        migrations.RunSQL(
+            sql="CREATE INDEX IF NOT EXISTS auth_user_username_ci_idx ON auth_user (upper(username));",
+            reverse_sql="DROP INDEX IF EXISTS auth_user_username_ci_idx;",
+        )
+    ]

--- a/models.py
+++ b/models.py
@@ -3,6 +3,7 @@ import threading
 
 from django.db import models
 from django.db.models import Q
+from django.db.models.functions import Lower
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
@@ -318,6 +319,9 @@ class UserAdditionalInfo(AuditedBaseModel):
 
         return None
 
+    def find_user_by_username(username):
+
+        return User.objects.filter(username__iexact=username).first()
 
 class AuthoringTool(TimestampedBaseModel):
     """

--- a/tests.py
+++ b/tests.py
@@ -448,3 +448,31 @@ class ValidationModelsTestCase(TestCase):
         # assert
         self.assertIsNone(company1)
         self.assertIsNone(company2)
+    
+    def test_find_user_by_username_should_succeed(self):
+
+        # arrange
+        ValidationModelsTestCase.set_user_context()
+        user = User.objects.create(id=2, username='JohnDoe', email='jdoe@acme.com', is_active=True)
+
+        # act
+        result = UserAdditionalInfo.find_user_by_username('johndoe') # notice: all lower case
+        result2 = UserAdditionalInfo.find_user_by_username('JOHNDOE') # notice: all upper case
+
+        # assert
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result2)
+        self.assertEqual(user, result)
+        self.assertEqual(user, result2)
+
+    def test_find_user_by_username_should_return_none(self):
+
+        # arrange
+        ValidationModelsTestCase.set_user_context()
+        user = User.objects.create(id=2, username='JohnDoe', email='jdoe@acme.com', is_active=True)
+
+        # act
+        result = UserAdditionalInfo.find_user_by_username('jane')
+
+        # assert
+        self.assertIsNone(result)


### PR DESCRIPTION
Result of this at DB level (compare via `UPPER(...) = UPPER(...)` is what `__iexact` does):

`EXPLAIN SELECT * from auth_user WHERE upper(username) = upper('rOOt');
`

```
Index Scan using auth_user_username_ci_idx on auth_user  (cost=0.14..8.16 rows=1 width=1767)
  Index Cond: (upper((username)::text) = 'ROOT'::text)
```

Confirmed it is now using an index.