### PR TITLE
Ivs 707 fix report rendering for nested dicts in als017

### DIFF
--- a/dataclass_compat.py
+++ b/dataclass_compat.py
@@ -51,7 +51,7 @@ class ValidationOutcomeCode(str, Enum):
 
 class FrozenDict(frozenset):
     def __repr__(self):
-        return repr(dict(self))
+        return f"FrozenDict({repr(dict(self))})"
 
 
 def freeze(obj):
@@ -60,7 +60,9 @@ def freeze(obj):
     Lists and tuples are converted to tuples.
     Strings are interned (todo benchmark)
     """
-    if isinstance(obj, Mapping):
+    if isinstance(obj, FrozenDict):
+        return obj
+    elif isinstance(obj, Mapping):
         return FrozenDict((k, freeze(v)) for k, v in obj.items())
     elif isinstance(obj, (list, tuple)):
         return tuple(freeze(v) for v in obj)

--- a/dataclass_compat.py
+++ b/dataclass_compat.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import IntEnum, Enum
 import sys
-from typing import Any, Optional, Union, Mapping, Sequence
+from typing import Any, Optional, Union, Sequence
+from collections.abc import Mapping
 
 JSONLike = Union[None, bool, int, float, str, Mapping[str, Any], Sequence[Any]]
 
@@ -52,7 +53,11 @@ class ValidationOutcomeCode(str, Enum):
 class FrozenDict(frozenset):
     def __repr__(self):
         return f"FrozenDict({repr(dict(self))})"
+    def items(self):
+        return dict(self).items()
 
+# Do not inherited concretely, because we don't want to inherit methods like __hash__ from Mapping
+Mapping.register(FrozenDict)
 
 def freeze(obj):
     """


### PR DESCRIPTION
Make FrozenDict behave more like a Mapping and register it as such so that when serialising to JSON in ifc-gherking-rules we don't serialise as an array.